### PR TITLE
V2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ superagentLogger(bunyan_logger[, options])
 * should use the plugin after the definiton of the http method to use
 * to capture the `X-Request-ID` should use this plugin after setting the `X-Request-ID` header
 * for more options to configure `bunyan.createLogger` or `log.child` check with [bunyan doc](https://github.com/trentm/node-bunyan#introduction)
-* will use `log.info` with http errors (status codes 4xx and 5xx)
-* will use `log.error` with socket errors
+* will use `log.error` with http errors (status codes 4xx and 5xx) and socket errors but for the http errors `res` will have the statusCode
 
 ### example
 ```js
@@ -87,7 +86,7 @@ request
 
 //
 // setting the X-Request-ID with superagent
-// and superagent-bunyan will use for the req.id
+// and superagent-bunyan will use to set the req.id
 //
 
 request

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-bunyan",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "a plugin for superagent that uses bunyan to log the request s and responses",
   "main": "index.js",
   "files": [
@@ -39,7 +39,10 @@
     "standard": "^8.6.0",
     "superagent": "^3.4.1"
   },
-  "dependencies": {},
+  "dependencies": {
+    "get-property-value": "^2.0.0",
+    "object.size": "^1.0.0"
+  },
   "engines": {
     "node": ">=6.1"
   },


### PR DESCRIPTION
- if using the header `X-Request-ID` superagent-bunyan will use the value for the `req.id`
- the initial request the query string will be logged
- add better tests cases